### PR TITLE
APPSRE-6954 - add authless option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ $ docker run --rm -it -e BASIC_AUTH_USERNAME='foo' -e BASIC_AUTH_PASSWORD='bar' 
 
 Note: When provided, `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` will
 have precedence over the `HTPASSWD` environment variable.
+
+To disable authentication for the pod, use the env variable `BASIC_AUTH_DISABLE=true`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,11 @@
 envsubst '$${FORWARD_HOST} $${LISTEN_PORT}' < nginx.conf > /tmp/nginx.conf
 envsubst < auth.htpasswd > /tmp/auth.htpasswd
 
+if [ "${BASIC_AUTH_DISABLE}" = "true" ]
+then
+    grep -v "auth_basic" /tmp/nginx.conf > /tmp/nginx_authless.conf
+    rm /tmp/nginx.conf
+    mv /tmp/nginx_authless.conf /tmp/nginx.conf
+fi
+
 nginx -c /tmp/nginx.conf


### PR DESCRIPTION
Allow nginx-gate to run without authentication. This is useful if running Qontract Server in an environment that doesn't need authentication, such as internally behind a VPN.

Similar to my work here: https://github.com/app-sre/visual-qontract/pull/162/files