### PR TITLE
APPSRE-8188 allow non-auth metrics path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ build:
 	@docker build -t $(IMAGE_NAME):latest .
 	@docker tag $(IMAGE_NAME):latest $(IMAGE_NAME):$(IMAGE_TAG)
 
+# For local testing purposes
+compose:
+	@docker compose up --build
+
 push:
 	@docker --config=$(DOCKER_CONF) push $(IMAGE_NAME):latest
 	@docker --config=$(DOCKER_CONF) push $(IMAGE_NAME):$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ Note: When provided, `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` will
 have precedence over the `HTPASSWD` environment variable.
 
 To disable authentication for the pod, use the env variable `BASIC_AUTH_DISABLE=true`
+
+## Metrics
+
+We allow an optional `METRICS_PATH` which will allow unauthenticated querying.
+This can be useful to easily expose metrics for prometheus.
+
+## Local Testing
+
+A docker compose stack is provided that can be used to verify paths are forwarded as expected.
+The compose stack starts multiple config flavors of the gate in parallel on different ports.
+
+```
+make compose
+```
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,36 @@
+---
+services:
+    nginx-gate-auth:
+        build: .
+        ports:
+        - "8081:8080"
+        links:
+        - test-host
+        environment:
+        - "FORWARD_HOST=test-host:80"
+        - "LISTEN_PORT=8080"
+        - "METRICS_PATH=/metrics"
+    nginx-gate-no-auth:
+        build: .
+        ports:
+        - "8082:8080"
+        links:
+        - test-host
+        environment:
+        - "FORWARD_HOST=test-host:80"
+        - "LISTEN_PORT=8080"
+        - "METRICS_PATH=/metrics"
+        - "BASIC_AUTH_DISABLE=true"
+    nginx-gate-no-metrics:
+        build: .
+        ports:
+        - "8083:8080"
+        links:
+        - test-host
+        environment:
+        - "FORWARD_HOST=test-host:80"
+        - "LISTEN_PORT=8080"
+    test-host:
+        image: nginx:stable-alpine3.17-slim
+        ports:
+        - 80

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@
 [ ! -z "${BASIC_AUTH_USERNAME}" ] && [ ! -z "${BASIC_AUTH_PASSWORD}" ] && \
     export HTPASSWD=$(htpasswd -bn "${BASIC_AUTH_USERNAME}" "${BASIC_AUTH_PASSWORD}")
 
-envsubst '$${FORWARD_HOST} $${LISTEN_PORT}' < nginx.conf > /tmp/nginx.conf
+envsubst '$${FORWARD_HOST} $${LISTEN_PORT} $${METRICS_PATH}' < nginx.conf > /tmp/nginx.conf
 envsubst < auth.htpasswd > /tmp/auth.htpasswd
 
 if [ "${BASIC_AUTH_DISABLE}" = "true" ]
@@ -13,6 +13,13 @@ then
     grep -v "auth_basic" /tmp/nginx.conf > /tmp/nginx_authless.conf
     rm /tmp/nginx.conf
     mv /tmp/nginx_authless.conf /tmp/nginx.conf
+fi
+
+if [ -z "${METRICS_PATH}" ]
+then
+    grep -v "# METRICS_MARKER" /tmp/nginx.conf > /tmp/nginx_metricless.conf
+    rm /tmp/nginx.conf
+    mv /tmp/nginx_metricless.conf /tmp/nginx.conf
 fi
 
 nginx -c /tmp/nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,12 @@ http {
       proxy_pass http://app;
     }
 
+    location = ${METRICS_PATH} {  # METRICS_MARKER
+      auth_basic "off";  # METRICS_MARKER
+      allow all;  # METRICS_MARKER
+      proxy_pass http://app${METRICS_PATH};  # METRICS_MARKER
+    }  # METRICS_MARKER
+
     location /healthz {
       access_log off;
       auth_basic "off";


### PR DESCRIPTION
In order to use `ServiceMonitor`s in combination with nginx-gate proxied apps, it would be helpful to have an un-authenticated path for metrics.

Further, this adds a compose file which can be used to quickly validate locally if the configuration looks as expected.