### PR TITLE
add config for PROXY_BUFFERING

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,10 +10,12 @@
 
 [ -z "$CACHE_KEY_INACTIVE_TIME" ] && export CACHE_KEY_INACTIVE_TIME=60m
 
+[ -z "$PROXY_BUFFERING" ] && export PROXY_BUFFERING=off
+
 [ ! -z "${BASIC_AUTH_USERNAME}" ] && [ ! -z "${BASIC_AUTH_PASSWORD}" ] && \
     export HTPASSWD=$(htpasswd -bn "${BASIC_AUTH_USERNAME}" "${BASIC_AUTH_PASSWORD}")
 
-envsubst '$${FORWARD_HOST} $${LISTEN_PORT} $${METRICS_PATH} $${CACHE_MAX_SIZE} $${CACHE_TTL} $${CACHE_KEYS_ZONE_SIZE} $${CACHE_KEY_INACTIVE_TIME} ' < nginx.conf > /tmp/nginx.conf
+envsubst '$${FORWARD_HOST} $${LISTEN_PORT} $${METRICS_PATH} $${CACHE_MAX_SIZE} $${CACHE_TTL} $${CACHE_KEYS_ZONE_SIZE} $${CACHE_KEY_INACTIVE_TIME} $${PROXY_BUFFERING} ' < nginx.conf > /tmp/nginx.conf
 envsubst < auth.htpasswd > /tmp/auth.htpasswd
 
 if [ "${BASIC_AUTH_DISABLE}" = "true" ]

--- a/nginx.conf
+++ b/nginx.conf
@@ -53,6 +53,8 @@ http {
         proxy_cache_valid 200 ${CACHE_TTL};  # Cache 200 responses for CACHE_TTL minutes
         proxy_pass http://app;  # Backend server URL
 
+        proxy_buffering ${PROXY_BUFFERING};
+
         add_header X-Cache-Status $upstream_cache_status;
 
         proxy_cache_bypass $http_x_skip_cache;  # Bypass cache if condition is met


### PR DESCRIPTION
Seeing errors such as below in stage testing.

```
2024/06/25 19:28:40 [error] 16#16: *3248 proxy_buffer_size 4096 is not enough for cache key, it should be increased to at least 8192, client: 10.129.3.229, server: _, request: "POST /graphqlsha/73fdcf4035858a9e7f50e3f38876047930b97f90981e18f53a0ffd82759a38f5 HTTP/1.1", host: "app-interface-nginx-gate:8080"
```

Proxy buffering is enabled by default, this change makes it configurable with default set to `off`. 

The current approach is to monitor nginx-gate in stage and see how this change goes.