### PR TITLE
Add proxy buffer configuration

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,12 +10,16 @@
 
 [ -z "$CACHE_KEY_INACTIVE_TIME" ] && export CACHE_KEY_INACTIVE_TIME=60m
 
-[ -z "$PROXY_BUFFERING" ] && export PROXY_BUFFERING=off
+[ -z "$PROXY_BUFFERS_NUMBER" ] && export PROXY_BUFFERS_NUMBER=8
+
+[ -z "$PROXY_BUFFERS_SIZE" ] && export PROXY_BUFFERS_SIZE=8k
+
+[ -z "$PROXY_BUFFER_SIZE" ] && export PROXY_BUFFER_SIZE=16k
 
 [ ! -z "${BASIC_AUTH_USERNAME}" ] && [ ! -z "${BASIC_AUTH_PASSWORD}" ] && \
     export HTPASSWD=$(htpasswd -bn "${BASIC_AUTH_USERNAME}" "${BASIC_AUTH_PASSWORD}")
 
-envsubst '$${FORWARD_HOST} $${LISTEN_PORT} $${METRICS_PATH} $${CACHE_MAX_SIZE} $${CACHE_TTL} $${CACHE_KEYS_ZONE_SIZE} $${CACHE_KEY_INACTIVE_TIME} $${PROXY_BUFFERING} ' < nginx.conf > /tmp/nginx.conf
+envsubst '$${FORWARD_HOST} $${LISTEN_PORT} $${METRICS_PATH} $${CACHE_MAX_SIZE} $${CACHE_TTL} $${CACHE_KEYS_ZONE_SIZE} $${CACHE_KEY_INACTIVE_TIME} $${PROXY_BUFFERS_NUMBER} $${PROXY_BUFFERS_SIZE} $${PROXY_BUFFER_SIZE}' < nginx.conf > /tmp/nginx.conf
 envsubst < auth.htpasswd > /tmp/auth.htpasswd
 
 if [ "${BASIC_AUTH_DISABLE}" = "true" ]

--- a/nginx.conf
+++ b/nginx.conf
@@ -53,7 +53,8 @@ http {
         proxy_cache_valid 200 ${CACHE_TTL};  # Cache 200 responses for CACHE_TTL minutes
         proxy_pass http://app;  # Backend server URL
 
-        proxy_buffering ${PROXY_BUFFERING};
+        proxy_buffers ${PROXY_BUFFERS_NUMBER} ${PROXY_BUFFERS_SIZE};
+        proxy_buffer_size ${PROXY_BUFFER_SIZE};
 
         add_header X-Cache-Status $upstream_cache_status;
 


### PR DESCRIPTION
APPSRE-9925

From https://www.f5.com/company/blog/nginx/avoiding-top-10-nginx-configuration-mistakes

> with proxy buffering disabled, rate limiting and caching don’t work even if configured

Based on above, I'm removing the configuration and adding new configuration to override parameters related to proxy buffer. 